### PR TITLE
Added Homelessness in Manchester page

### DIFF
--- a/site/content/homelessness-in-manchester/_index.md
+++ b/site/content/homelessness-in-manchester/_index.md
@@ -1,0 +1,135 @@
+---
+title: Homelessness in Manchester
+hero:
+  image: /assets/images/streetwise-opera.jpg
+about:
+  body: >-
+    Homelessness is complex and anyone who is currently without a home should be viewed as
+    an individual - not as part of a homogenous ‘homeless’ group. Lots of different people find
+    themselves in lots of different situations of homelessness for lots of different reasons.
+
+    
+    > ## *Rough sleeping represents the smallest segment of the homeless population.*
+
+
+    Often people think about people who are street homelessness or rough sleeping, but this
+    represents the smallest segment of the homeless population (2-5% in Manchester). Other
+    circumstances include people who are in emergency shelters, temporary accommodation,
+    sofa-surfing, unsafe / substandard housing, and those who are at risk of being homeless.
+
+
+    Anyone can become homeless, but it is often linked to poverty. We see a higher
+    representation of people who have left the care system (~30%), prison system (~20%), and
+    military (~20%). As well as a greater prominence of mental health conditions (~70%),
+    substance misuse, and experiences of ACTs (acute-childhood trauma).
+
+
+    > ## *There are often several compounding factors which lead to someone being in a situation of homelessness.*
+
+
+    The main cited reason for why someone becomes homeless in the UK is ‘relationship
+    breakdown’, in Manchester it is ‘eviction from private-tenancy’. In reality, there are often several compounding factors which lead to someone being in a situation of homelessness.
+    For example; abuse, debt, and separation from their social support networks.
+
+    Homelessness has increased across the whole of the UK in the last ten years and there are
+    many external pressures which are influencing this:
+
+    
+    * Not enough social housing
+
+    * Social housing stock being privately owned and managed
+
+    * Not enough affordable housing
+
+    * Section 106 (affordable housing requirements) being negotiated out of privately
+
+    * Building houses but not building neighborhoods &amp; social infrastructure
+    * People not being part of a community or other social support networks
+
+    * Letting agents who discriminate against ‘DSS’ tenants or young people
+
+    * Regeneration strategies that do not meet the needs of all citizens
+
+    * Cities and spaces that you can only enjoy or feel a part of if you have money
+
+    * Cuts to local government budgets and staffing
+
+    * Reforms to the welfare system (Universal Credit)
+
+    * Growing disparities in wealth distribution
+
+    * Cyclical poverty and associated patterns of behaviours
+
+    * A state support system and processes which does not fit the people it is for
+
+
+    If you are homeless (or at risk of becoming homeless) you have to present at your local
+    authority who will decided if there is a ‘statutory duty’ for them to support you.
+
+  heading: Homelessness Context
+howToHelp:
+  body: >-
+    There are lots of ways you can contribute to our aim of ending homelessness. The
+    organisations in our network post what they need on Street Support – have a look on Give
+    Help and see if there is anything you can respond to. There are also some bigger,
+    reoccurring, or more urgent needs which you might be able to help with:
+
+
+    ## Bigger picture – systems change
+
+    ### Community support
+
+    The prevention of homelessness often starts with a conversation. If there is a friend,
+    family member, neighbour or colleague who you are worried about - speak up.
+
+    ### Ethical business practices
+
+    You might have a strong social value arm of your business, but do you follow ethical
+    business practices? (E.g. having a mental health policy and a good pay ratio). What
+    support mechanisms are in place for colleagues who might be at risk of, or
+    experiencing a form of homelessness?
+
+    ### Advocacy
+
+    Use your influence and networks to advocate and campaign for change on the wider
+    factors that are causing more people to become homeless. This would include:
+      * Need for more social, affordable housing and adherence to S106
+      * More inclusive and transparent processes for how city decisions are made
+      * Improved mechanisms for citizens to be informed on and influence policy
+      * Greater public awareness around the ‘bigger picture’ of homelessness
+
+
+    ## Urgent network needs
+
+    ### Premises
+    
+    Many charities and services need a permanent base in the city centre. Do you have
+    any land or building space which could be utilised by one of our partners?
+
+    ### Renovations
+
+    There are a number of drop-in centres and accommodation provisions that could be
+    improved. Get in touch to find out more.
+
+    ### Employment
+
+    We would like to work with any organisation who is interested in inclusive
+    recruitment. Get in touch to find out more.
+
+  
+    ## Reoccurring network needs
+
+    ### Venues
+
+    We need regular city centre hosts for meetings and groups, with catering if possible.
+    
+    
+    Do you have any rooms we could book or use?
+
+    ### Regular items
+
+    We have a shared storage facility which needs to stay stocked up with coffee, tea,
+    sugar, tinned goods, underwear, and toiletries. Can you donate these items?
+  heading: How to help?
+---
+

--- a/site/layouts/homelessness-in-manchester/homelessness-in-manchester.html
+++ b/site/layouts/homelessness-in-manchester/homelessness-in-manchester.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html class="no-js single" lang="en-GB" xmlns:fb="http://ogp.me/ns/fb#">
+{{- partial "head.html" . -}}
+
+<body>
+  {{- partial "header.html" . -}}
+  <main id="main">
+    <section class="block">
+      <div {{ if(ne .Params.hero.image nil) }} class="block__image block__image--bg block__image--bg-missing-image"
+        {{ else }} class="block__image block__image--bg" {{ end }} {{ if (ne .Params.hero.image nil) }}
+        style="background-image: url({{ .Params.hero.image }})" {{ end }}>
+        <div class="container">
+          <header class="block__header">
+            <h1 class="block__header-title">{{ .Params.about.heading }}</h1>
+            {{ if (ne .Params.about.subHeading nil) }}
+            <p class="block__header-sub-title">{{ .Params.about.subHeading }}</p>
+            {{ end }}
+          </header>
+        </div>
+      </div>
+      <div class="container">
+        <div class="block__body block__body--drop-shadow">
+          {{ $bodyMarkdown := .Params.about.body | markdownify }}
+          {{ if not ( strings.Contains $bodyMarkdown "<p>" ) }}<p>{{ $bodyMarkdown }}</p>
+          {{ else }}{{ $bodyMarkdown }}{{ end }}
+        </div>
+      </div>
+    </section>
+
+    {{ if (ne .Params.howToHelp.body nil) }}
+    <section class="block">
+      <div class="container">
+        <header class="block__header">
+          <h1 class="block__header-title">{{ .Params.howToHelp.heading }}</h1>
+          {{ if (ne .Params.howToHelp.subHeading nil) }}
+          <p class="block__header-sub-title">{{ .Params.howToHelp.subHeading }}</p>
+          {{ end }}
+        </header>
+        <div class="block__body block__body--drop-shadow">
+          {{ $bodyMarkdown := .Params.howToHelp.body | markdownify }}
+          {{ if not ( strings.Contains $bodyMarkdown "<p>" ) }}<p>{{ $bodyMarkdown }}</p>
+          {{ else }}{{ $bodyMarkdown }}{{ end }}
+        </div>
+      </div>
+    </section>
+    {{ end }}
+
+  </main>
+  {{ $footer := .Site.GetPage "_footer.md" }}
+  {{ partial "footer.html" (dict "footer" $footer) }}
+
+  {{ $script := .Site.Data.webpack.main }}
+  {{ with $script.js }}
+  <script src="{{ relURL . }}"></script>
+  {{ end }}
+</body>
+
+</html>


### PR DESCRIPTION
**- Summary**
Added "Homelessness in Manchester" page as per issue #8 
The background photo is the same as the one used for the "Homelessness Strategy" page, as this is what the page is based off, so that might need changing. I pulled a couple of quotes out to break up the text - I'm not sure if there's a particular style guide for these so they might want formatting differently.

**- Test plan**
I couldn't find any automated tests, so here's some screenshots  of the page running at http://localhost:3000/homelessness-in-manchester/:

![content at the top of the page](https://user-images.githubusercontent.com/3097422/56347936-4e301d00-61bd-11e9-9e42-f82e4eec0662.png)

![more content](https://user-images.githubusercontent.com/3097422/56347999-6e5fdc00-61bd-11e9-82b3-1c8bd1131555.png)



**- Description for the changelog**

Created markdown and layout files for the "Homelessness in Manchester" page

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.ancient-origins.net/sites/default/files/field/image/Hedgehog.jpg)